### PR TITLE
chore: swap out obsolete network spawn in manager

### DIFF
--- a/code/NetworkManager.cs
+++ b/code/NetworkManager.cs
@@ -24,6 +24,6 @@ public class NetworkManager : Component, Component.INetworkListener
 	{
 		var player = PlayerPrefab.Clone();
 		player.BreakFromPrefab();
-		player.Network.Spawn( connection );
+		player.NetworkSpawn( connection );
 	}
 }


### PR DESCRIPTION
First PR for s&box 🚀 , although simple its something. This just swaps out a obsolete fn with the recommended change. 